### PR TITLE
[ADO-3142975] Migrate from Checkmarx to Checkmarx One

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
  orbs:
-   checkmarx: justgiving/checkmarx@1.0.0
+   checkmarx: justgiving/checkmarx@2.0.0
    whitesource: justgiving/whitesource@1.0.0
 
  workflows:
@@ -19,7 +19,6 @@ version: 2.1
        - checkmarx/scan:
            name: checkmarx
            context: security-checkmarx
-           registry-url: 651244981378.dkr.ecr.eu-west-1.amazonaws.com
            filters:
              branches:
                only: master


### PR DESCRIPTION
This PR migrates the security scanning workflow from Checkmarx to Checkmarx One.

ADO References:
- <https://dev.azure.com/blackbaud/Products/_workitems/edit/3142975/>
- <https://dev.azure.com/blackbaud/Products/_workitems/edit/3134621/>